### PR TITLE
Bugfix/owner can edit permission requests

### DIFF
--- a/src/containers/permissions/components/EntitySetPermissionsRequest.js
+++ b/src/containers/permissions/components/EntitySetPermissionsRequest.js
@@ -84,15 +84,14 @@ class EntitySetPermissionsRequest extends React.Component {
     this.setState({ selectedProperties });
   }
 
-  renderProperty(principalId, propertyType) {
-    const checked = this.state.selectedProperties.has(propertyType.id);
+  renderProperty(principalId, propertyType, defaultChecked) {
     return (
       <div className="propertyType" key={propertyType.id}>
         <div className="propertyTypePermissions">
           <input
               type="checkbox"
               id={`ptr-${principalId}-${propertyType.id}`}
-              defaultChecked={checked}
+              defaultChecked={defaultChecked}
               onClick={(e) => {
                 this.toggleCheckbox(e.target.checked, propertyType.id);
               }}


### PR DESCRIPTION
there's issues we'll run into here once we start making more complex permissions requests, e.g. how do we differentiate between different levels of permissions requests for different properties (read for one, read and write for another), and how can the owner change these levels/choose a level for extra permissions they add? For now I'm just choosing the settings of the first request from a user as the default for any added requests, but we'll eventually need a more sophisticated UI for this and we'll need to rework this logic a bit. also, should deselecting a box and hitting "accept" automatically reject the deselected box? what about deselecting and then hitting "reject"?