### PR TITLE
Explicitly set width for IE11

### DIFF
--- a/src/containers/home/styles.module.css
+++ b/src/containers/home/styles.module.css
@@ -19,6 +19,7 @@
   -webkit-align-items: flex-start;
   align-items: flex-start;
   text-align: center;
+  width: 100%;
 }
 
 .instructionsBox:hover {
@@ -48,6 +49,7 @@
   color: #1879fb;
   padding: 20px;
   font-size: 14px;
+  width: 100%;
 }
 
 .getStartedMessage {


### PR DESCRIPTION
- text and instructions box width: 100%

Fixes LOOMWEB-192